### PR TITLE
refactor: Detect planes with `ARPlaneAnchor` instead of `ARMeshAnchor`

### DIFF
--- a/Augmented Reality/DimensionsAR/DimensionsAR/Utils/GestureManager.swift
+++ b/Augmented Reality/DimensionsAR/DimensionsAR/Utils/GestureManager.swift
@@ -175,7 +175,6 @@ private extension GestureManager {
 
                     // Normalized normal vector in scene's world coordinates.
                     let faceNormalInWorld = normalize(boundingBox.simdConvertVector(face.normal, to: nil))
-                    print("Face normal in world:", faceNormalInWorld)
 
                     let ray = Ray(origin: SIMD3<Float>(result.worldCoordinates), direction: faceNormalInWorld)
                     let transform = dragPlaneTransform(for: ray, cameraPos: camera.simdWorldPosition)


### PR DESCRIPTION
This PR will refactor the existing code with plain plane detection without using mesh reconstruction, which is not supported on older devices. The functionality remains the same.